### PR TITLE
Refactoring sla-aware drain sub-command

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 0.0.9 (unreleased)
 
 * Added ability to create jobs which contain an executorless docker container.
+* Sla-aware draining sub-command has been simplified. Instead of having a count/percentage
+  subcommand, it now has a flag for each of these options. The count and percentage flag are
+  mutually exclusive, and one of them has to be set.
 
 0.0.8
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -80,7 +80,9 @@ var rootCmd = &cobra.Command{
 }
 
 func Execute() {
-	rootCmd.Execute()
+	if err := rootCmd.Execute(); err != nil {
+		log.Fatal(err)
+	}
 }
 
 // TODO(rdelvalle): Move more from connect into this function

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,11 @@
 australis (0.0.9) unstable; urgency=medium
 
-  * Unreleased
+  * added ability to create jobs which contain an executorless docker container.
+  * sla-aware draining sub-command has been simplified. instead of having a count/percentage
+    subcommand, it now has a flag for each of these options. the count and percentage flag are
+    mutually exclusive, and one of them has to be set.
 
- -- Renan DelValle <renanidelvalle@gmail.com>  Fri, 25 Mar 2019 15:10:00 -0700
+ -- Renan DelValle <renanidelvalle@gmail.com>  Wed, 29 Jan 2020 15:10:00 -0700
 
 australis (0.0.8) unstable; urgency=medium
 

--- a/go.mod
+++ b/go.mod
@@ -12,3 +12,5 @@ require (
 	github.com/spf13/viper v1.3.1
 	gopkg.in/yaml.v2 v2.2.2
 )
+
+go 1.13


### PR DESCRIPTION
Changing sla-aware command to be less cumbersome. sla-aware command now takes --count or --percentage and they are mutually exclusive.